### PR TITLE
Add Hetzner price push to Coroot custom cloud pricing

### DIFF
--- a/.github/workflows/copy-secrets-coroot.yml
+++ b/.github/workflows/copy-secrets-coroot.yml
@@ -1,0 +1,36 @@
+name: Copy Org Secrets to Repo
+
+# Copies org-level secrets into this repo so hetzner-prices.yml can use them.
+# Requires PUSH_TOKEN (org-level PAT with secrets:write on this repo).
+#
+# Run this once after rotating org-level secrets, or whenever the repo-level
+# copies need refreshing.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  copy-secrets:
+    name: Copy secrets to coroot-cicd
+    runs-on: ubuntu-latest
+    steps:
+      - name: Copy HETZNER_TOKEN
+        env:
+          GH_TOKEN: ${{ secrets.PUSH_TOKEN }}
+        run: |
+          printf '%s' "${{ secrets.HETZNER_TOKEN }}" | gh secret set HETZNER_TOKEN \
+            --repo atvirokodosprendimai/coroot-cicd
+
+      - name: Copy COROOT_EMAIL
+        env:
+          GH_TOKEN: ${{ secrets.PUSH_TOKEN }}
+        run: |
+          printf '%s' "${{ secrets.COROOT_EMAIL }}" | gh secret set COROOT_EMAIL \
+            --repo atvirokodosprendimai/coroot-cicd
+
+      - name: Copy COROOT_PASSWORD
+        env:
+          GH_TOKEN: ${{ secrets.PUSH_TOKEN }}
+        run: |
+          printf '%s' "${{ secrets.COROOT_PASSWORD }}" | gh secret set COROOT_PASSWORD \
+            --repo atvirokodosprendimai/coroot-cicd

--- a/.github/workflows/hetzner-prices.yml
+++ b/.github/workflows/hetzner-prices.yml
@@ -1,0 +1,38 @@
+name: Hetzner Price Push
+
+# Derives per-CPU and per-memory hourly rates from active Hetzner server
+# pricing and updates Coroot's custom cloud pricing via its project API.
+# Runs directly on the GHA runner — no SSH to VPS required.
+#
+# Required secrets: HETZNER_TOKEN, COROOT_EMAIL, COROOT_PASSWORD
+# Optional vars:    COROOT_PROJECT (auto-discovered from API if unset)
+
+on:
+  schedule:
+    # Daily at 06:00 UTC
+    - cron: "0 6 * * *"
+
+  workflow_dispatch:
+
+jobs:
+  push-prices:
+    name: Push Hetzner Prices to Coroot
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Derive and push pricing
+        env:
+          HETZNER_TOKEN: ${{ secrets.HETZNER_TOKEN }}
+          COROOT_EMAIL: ${{ secrets.COROOT_EMAIL }}
+          COROOT_PASSWORD: ${{ secrets.COROOT_PASSWORD }}
+          COROOT_URL: https://table.beerpub.dev
+          COROOT_PROJECT: ${{ vars.COROOT_PROJECT }}
+        run: python3 scripts/push-hz-prices.py
+
+      - name: Summary
+        if: success()
+        run: |
+          echo "### Hetzner Prices Updated" >> $GITHUB_STEP_SUMMARY
+          echo "Custom cloud pricing updated in Coroot (project auto-discovered or from \`COROOT_PROJECT\` var)." >> $GITHUB_STEP_SUMMARY

--- a/TASKS.md
+++ b/TASKS.md
@@ -6,3 +6,4 @@ need to launch coroot server on hz vps, using domain: table.beerpub.dev
 - [x] Document Docker `expose:` vs `ports:` implications in DEPLOY.md
 - [x] Order Hetzner Storage Box and configure SSH key + `/etc/coroot-backup.conf` on VPS (see DEPLOY.md for setup instructions)
 - [x] Split repos — RFC-EDPROOF.md and formal/edproof.spthy moved to https://github.com/atvirokodosprendimai/edproof
+- [x] Fetch prices from Hetzner console and push them to Coroot

--- a/memory/next - 2602221502 - one open task hz-prices-to-coroot.md
+++ b/memory/next - 2602221502 - one open task hz-prices-to-coroot.md
@@ -1,0 +1,12 @@
+# Next — 2602221502
+
+## Actionable Items
+
+1 - Todos (TASKS.md)
+  - 1.1 - Fetch prices from Hetzner console and push them to Coroot
+
+## Notes
+
+- No plans, goodjobs, or open {{comments}} found
+- Branch `task/hz-prices-to-coroot` has uncommitted change to TASKS.md (todo added this session)
+- All other TASKS.md items are checked [x]

--- a/memory/next - 2602281014 - hz-prices impl complete ready to commit.md
+++ b/memory/next - 2602281014 - hz-prices impl complete ready to commit.md
@@ -1,0 +1,17 @@
+# Next — 2602281014
+
+## Actionable Items
+
+1 - Branch work ready to commit (task/hz-prices-to-coroot)
+  - 1.1 - Commit + push: scripts/push-hz-prices.py, hetzner-prices.yml,
+          copy-secrets-coroot.yml, DEPLOY.md, TASKS.md
+  - 1.2 - Merge/PR task/hz-prices-to-coroot → main
+
+## Notes
+
+- All TASKS.md items are [x] — no remaining todos
+- New untracked files: scripts/push-hz-prices.py, .github/workflows/hetzner-prices.yml,
+  .github/workflows/copy-secrets-coroot.yml, memory/
+- Modified: DEPLOY.md (new Hetzner Price Metrics section), TASKS.md (task checked off)
+- Implementation derives per-CPU/per-memory hourly rates from Hetzner API,
+  posts to Coroot custom cloud pricing endpoint — runs daily via GHA cron

--- a/scripts/push-hz-prices.py
+++ b/scripts/push-hz-prices.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Derive per-CPU and per-memory hourly pricing from Hetzner Cloud and
+update Coroot's custom cloud pricing via its project API.
+
+Fetches all active servers from the Hetzner API, sums their hourly costs and
+resource totals, then splits the blended rate into per-CPU-core and
+per-memory-GB values using the same CPU:memory ratio as Coroot's GCP baseline.
+Authenticates to Coroot, auto-discovers the project name, then posts the
+derived rates to /api/project/{project}/custom_cloud_pricing.
+
+Required env:
+  HETZNER_TOKEN    — Hetzner Cloud API token
+  COROOT_EMAIL     — Coroot admin email
+  COROOT_PASSWORD  — Coroot admin password
+
+Optional env:
+  COROOT_URL       — Coroot base URL (default: https://table.beerpub.dev)
+  COROOT_PROJECT   — Project name override (auto-discovered from API if unset)
+"""
+
+import http.cookiejar
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+# --- Config ---
+
+HETZNER_TOKEN = os.environ.get("HETZNER_TOKEN")
+COROOT_EMAIL = os.environ.get("COROOT_EMAIL")
+COROOT_PASSWORD = os.environ.get("COROOT_PASSWORD")
+
+for var in ("HETZNER_TOKEN", "COROOT_EMAIL", "COROOT_PASSWORD"):
+    if not os.environ.get(var):
+        sys.exit(f"error: {var} not set")
+
+COROOT_URL = os.environ.get("COROOT_URL", "https://table.beerpub.dev").rstrip("/")
+COROOT_PROJECT = os.environ.get("COROOT_PROJECT", "")
+
+# CPU:memory cost ratio — matches Coroot's GCP C4 baseline
+# (0.03465 USD/vCPU/hr ÷ 0.003938 USD/GB/hr ≈ 8.8)
+CPU_MEMORY_RATIO = 0.03465 / 0.003938
+
+
+# --- Helpers ---
+
+def hetzner_get(path: str) -> dict:
+    req = urllib.request.Request(
+        f"https://api.hetzner.cloud{path}",
+        headers={"Authorization": f"Bearer {HETZNER_TOKEN}"},
+    )
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        return json.loads(resp.read())
+
+
+# Coroot session — cookie jar persists the auth cookie across requests
+_jar = http.cookiejar.CookieJar()
+_opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(_jar))
+
+
+def coroot_request(method: str, path: str, body: dict | None = None) -> dict | None:
+    data = json.dumps(body).encode() if body is not None else None
+    headers = {"Content-Type": "application/json"} if data else {}
+    req = urllib.request.Request(
+        f"{COROOT_URL}{path}",
+        data=data,
+        method=method,
+        headers=headers,
+    )
+    try:
+        with _opener.open(req, timeout=15) as resp:
+            raw = resp.read()
+            return json.loads(raw) if raw.strip() else None
+    except urllib.error.HTTPError as e:
+        body_text = e.read().decode(errors="replace").strip()
+        raise RuntimeError(f"HTTP {e.code} {method} {path}: {body_text}") from e
+
+
+# --- 1. Fetch Hetzner pricing ---
+
+print("Fetching Hetzner pricing catalog...")
+pricing = hetzner_get("/v1/pricing")["pricing"]
+
+price_lookup: dict[str, dict[str, dict]] = {
+    st["name"]: {
+        p["location"]: {
+            "hourly": float(p["price_hourly"]["net"]),
+            "monthly": float(p["price_monthly"]["net"]),
+        }
+        for p in st["prices"]
+    }
+    for st in pricing["server_types"]
+}
+
+print("Fetching active servers...")
+servers = hetzner_get("/v1/servers")["servers"]
+
+if not servers:
+    sys.exit("error: no active servers found in Hetzner account")
+
+# --- 2. Aggregate cost and resources ---
+
+total_hourly = 0.0
+total_vcpus = 0
+total_ram_gb = 0.0
+
+print()
+for server in servers:
+    stype = server["server_type"]["name"]
+    vcpus = server["server_type"]["cores"]
+    ram_gb = server["server_type"]["memory"]
+    location = server["datacenter"]["location"]["name"]
+    prices = price_lookup.get(stype, {}).get(location)
+
+    if not prices:
+        print(f"  {server['name']}: no price found for {stype}@{location}, skipping")
+        continue
+
+    total_hourly += prices["hourly"]
+    total_vcpus += vcpus
+    total_ram_gb += ram_gb
+    print(
+        f"  {server['name']}: {stype} @ {location}"
+        f" — {prices['monthly']:.4f} EUR/mo, {vcpus} vCPU, {ram_gb:.0f} GB RAM"
+    )
+
+if total_vcpus == 0:
+    sys.exit("error: could not resolve pricing for any active server")
+
+# --- 3. Derive per-CPU and per-memory rates ---
+#
+# Solve: per_cpu * vcpus + per_memory * ram = total_hourly
+#        per_cpu = CPU_MEMORY_RATIO * per_memory
+# =>     per_memory = total_hourly / (CPU_MEMORY_RATIO * vcpus + ram)
+
+per_memory = total_hourly / (CPU_MEMORY_RATIO * total_vcpus + total_ram_gb)
+per_cpu = CPU_MEMORY_RATIO * per_memory
+
+print()
+print(f"Blended rate  : {total_hourly:.6f} EUR/hr ({total_vcpus} vCPU, {total_ram_gb:.0f} GB)")
+print(f"per_cpu_core  : {per_cpu:.6f} EUR/hr")
+print(f"per_memory_gb : {per_memory:.6f} EUR/hr")
+
+assert abs(per_cpu * total_vcpus + per_memory * total_ram_gb - total_hourly) < 1e-9
+
+# --- 4. Authenticate to Coroot ---
+
+print(f"\nLogging in to {COROOT_URL} ...")
+coroot_request("POST", "/api/login", {"email": COROOT_EMAIL, "password": COROOT_PASSWORD})
+print("Authenticated.")
+
+# --- 5. Discover project name ---
+
+if not COROOT_PROJECT:
+    print("Discovering project name...")
+    # Try the dedicated projects list endpoint first, fall back to probing "default"
+    try:
+        projects = coroot_request("GET", "/api/projects") or []
+        if isinstance(projects, list) and projects:
+            COROOT_PROJECT = projects[0].get("name") or projects[0].get("id", "default")
+            print(f"  Found projects: {[p.get('name') or p.get('id') for p in projects]}")
+            print(f"  Using: {COROOT_PROJECT}")
+        else:
+            raise ValueError("empty projects list")
+    except Exception as e:
+        print(f"  /api/projects unavailable ({e}), probing overview endpoints...")
+        for candidate in ("default",):
+            try:
+                resp = coroot_request("GET", f"/api/project/{candidate}/overview")
+                if resp is not None:
+                    COROOT_PROJECT = candidate
+                    print(f"  Using: {COROOT_PROJECT}")
+                    break
+            except RuntimeError:
+                pass
+        else:
+            sys.exit(
+                "error: could not auto-discover project name. "
+                "Set COROOT_PROJECT env var explicitly."
+            )
+
+# --- 6. Update Coroot custom cloud pricing ---
+
+endpoint = f"/api/project/{COROOT_PROJECT}/custom_cloud_pricing"
+print(f"\nPosting rates to {COROOT_URL}{endpoint} ...")
+coroot_request("POST", endpoint, {"per_cpu_core": per_cpu, "per_memory_gb": per_memory})
+print("Done.")


### PR DESCRIPTION
## Summary

- Adds `scripts/push-hz-prices.py` — derives blended per-CPU-core and per-memory-GB hourly rates from active Hetzner Cloud servers and posts them to Coroot's custom cloud pricing API
- Adds `hetzner-prices.yml` GHA workflow — runs daily at 06:00 UTC (and on-demand), no VPS SSH required
- Adds `copy-secrets-coroot.yml` — one-shot helper to copy org-level secrets into the repo
- Documents setup in DEPLOY.md under "Hetzner Price Metrics"

## Test Plan

- [ ] Add secrets: `HETZNER_TOKEN`, `COROOT_EMAIL`, `COROOT_PASSWORD` via `gh secret set`
- [ ] Run `gh workflow run hetzner-prices.yml` and verify the workflow succeeds
- [ ] Confirm custom cloud pricing appears in Coroot dashboards for the project